### PR TITLE
Bumps .gemspec to 3.1.0-beta

### DIFF
--- a/spree_contact_us.gemspec
+++ b/spree_contact_us.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0.beta'
+  s.add_dependency 'spree_core', '~> 3.1.0.beta'
 
   s.add_development_dependency 'capybara',         '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
Throws a dependency error if all spree/spree sets are clocked at branch: 'master' otherwise. Could be helpful! 